### PR TITLE
More verbose error messages

### DIFF
--- a/segment/client.go
+++ b/segment/client.go
@@ -75,9 +75,9 @@ func (c *Client) doRequest(method, endpoint string, data interface{}) ([]byte, e
 	case http.StatusUnauthorized:
 		return nil, &SegmentApiError{Message: "invalid access token", Code: resp.StatusCode}
 	case http.StatusForbidden:
-		return nil, &SegmentApiError{Message: "unauthorized access to endpoint", Code: resp.StatusCode}
+		return nil, &SegmentApiError{Message: fmt.Sprintf("unauthorized access to endpoint: %s", endpoint), Code: resp.StatusCode}
 	case http.StatusNotFound:
-		return nil, &SegmentApiError{Message: "the requested uri does not exist", Code: resp.StatusCode}
+		return nil, &SegmentApiError{Message: fmt.Sprintf("the requested uri does not exist: %s", uri), Code: resp.StatusCode}
 	case http.StatusBadRequest, http.StatusInternalServerError:
 		return nil, handleErrorRequest(resp.Body)
 	case http.StatusTooManyRequests:
@@ -103,7 +103,7 @@ func handleErrorRequest(body io.ReadCloser) error {
 	var segmentErr SegmentApiError
 	err = json.Unmarshal(errBody, &segmentErr)
 	if err != nil {
-		return fmt.Errorf("request error unkown %s", errBody)
+		return fmt.Errorf("request error unkown: %s", errBody)
 	}
 
 	return &segmentErr

--- a/segment/client.go
+++ b/segment/client.go
@@ -103,7 +103,7 @@ func handleErrorRequest(body io.ReadCloser) error {
 	var segmentErr SegmentApiError
 	err = json.Unmarshal(errBody, &segmentErr)
 	if err != nil {
-		return fmt.Errorf("request error unkown: %s", errBody)
+		return fmt.Errorf("request error unknown: %s", errBody)
 	}
 
 	return &segmentErr

--- a/segment/client_test.go
+++ b/segment/client_test.go
@@ -90,7 +90,7 @@ func Test_doRequest_httpError_badRequestUnstructured(t *testing.T) {
 	setup()
 	defer teardown()
 
-	expected := "request error unkown bad request\n"
+	expected := "request error unkown: bad request\n"
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "bad request", 400)

--- a/segment/client_test.go
+++ b/segment/client_test.go
@@ -90,7 +90,7 @@ func Test_doRequest_httpError_badRequestUnstructured(t *testing.T) {
 	setup()
 	defer teardown()
 
-	expected := "request error unkown: bad request\n"
+	expected := "request error unknown: bad request\n"
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, _ *http.Request) {
 		http.Error(w, "bad request", 400)


### PR DESCRIPTION
Makes error messages for 403/404 errors more verbose to make debugging easier in the terraform context.